### PR TITLE
fix: correct repository URL for OIDC provenance

### DIFF
--- a/sdks/javascript/package.json
+++ b/sdks/javascript/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/togglerino/togglerino",
+    "url": "https://github.com/joCur/togglerino",
     "directory": "sdks/javascript"
   },
   "devDependencies": {

--- a/sdks/react/package.json
+++ b/sdks/react/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/togglerino/togglerino",
+    "url": "https://github.com/joCur/togglerino",
     "directory": "sdks/react"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Fix `repository.url` in both SDK `package.json` files from `github.com/togglerino/togglerino` to `github.com/joCur/togglerino`
- npm OIDC provenance validation requires the repository URL to exactly match the GitHub repo the workflow runs from

## Context
The publish-sdks workflow was failing with:
```
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/togglerino/togglerino.git",
expected to match "https://github.com/joCur/togglerino" from provenance
```

## Test plan
- [ ] CI passes
- [ ] After merge, trigger a SDK release and verify npm publish succeeds with provenance