### PR TITLE
chore: update claude code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
       "Bash(go get:*)",
       "Bash(go test:*)",
 
-      "Bash(docker compose:*",
+      "Bash(docker compose:*)",
 
       "Bash(npx vite:*)",
       "mcp__plugin_playwright_playwright__browser_navigate",
@@ -33,5 +33,8 @@
       "Bash(npm run:*)",
       "Bash(npm install:*)"
     ]
+  },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   }
 }


### PR DESCRIPTION
## Summary
- Fix missing closing parenthesis in `Bash(docker compose:*)` permission pattern
- Enable `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` env variable

## Test plan
- [x] Verify `docker compose` commands are properly allowed by the fixed permission pattern
- [x] Confirm agent teams feature works in Claude Code sessions