### PR TITLE
fix: .NET SDK release to NuGet.org never triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
-      dotnet-sdk--release_created: ${{ steps.release.outputs['dotnet-sdk--release_created'] }}
-      dotnet-sdk--tag_name: ${{ steps.release.outputs['dotnet-sdk--tag_name'] }}
+      dotnet-sdk--release_created: ${{ steps.release.outputs['sdks/dotnet--release_created'] }}
+      dotnet-sdk--tag_name: ${{ steps.release.outputs['sdks/dotnet--tag_name'] }}
       sdk--release_created: ${{ steps.release.outputs['sdks/javascript--release_created'] }}
       sdk--tag_name: ${{ steps.release.outputs['sdks/javascript--tag_name'] }}
       react--release_created: ${{ steps.release.outputs['sdks/react--release_created'] }}


### PR DESCRIPTION
## Summary

- Fixes release-please output key mismatch that prevented the `publish-dotnet-sdk` job from ever triggering
- Changed `steps.release.outputs['dotnet-sdk--release_created']` to `steps.release.outputs['sdks/dotnet--release_created']` (path-based key, matching JS/React SDK pattern)

Closes #89

## Root Cause

release-please-action v4 keys monorepo outputs by **package path** (`sdks/dotnet--`), not component name (`dotnet-sdk--`). The JS and React SDKs correctly used paths (`sdks/javascript--`, `sdks/react--`), but the dotnet SDK used the component name, so the output was always undefined and the publish job was always skipped.

## Test plan

- [ ] Verify next release-please PR includes `dotnet-sdk` component when `sdks/dotnet/` is touched
- [ ] Confirm `publish-dotnet-sdk` job triggers (no longer skipped) when dotnet-sdk release is created
- [ ] Ensure `NUGET_USER` secret and NuGet OIDC trusted publishing are configured (infrastructure prerequisite, not part of this PR)