### PR TITLE
fix: consistent release workflow output names and trigger dotnet-sdk release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      js-sdk--release_created: ${{ steps.release.outputs['sdks/javascript--release_created'] }}
+      js-sdk--tag_name: ${{ steps.release.outputs['sdks/javascript--tag_name'] }}
+      react-sdk--release_created: ${{ steps.release.outputs['sdks/react--release_created'] }}
+      react-sdk--tag_name: ${{ steps.release.outputs['sdks/react--tag_name'] }}
       dotnet-sdk--release_created: ${{ steps.release.outputs['sdks/dotnet--release_created'] }}
       dotnet-sdk--tag_name: ${{ steps.release.outputs['sdks/dotnet--tag_name'] }}
-      sdk--release_created: ${{ steps.release.outputs['sdks/javascript--release_created'] }}
-      sdk--tag_name: ${{ steps.release.outputs['sdks/javascript--tag_name'] }}
-      react--release_created: ${{ steps.release.outputs['sdks/react--release_created'] }}
-      react--tag_name: ${{ steps.release.outputs['sdks/react--tag_name'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -114,12 +114,12 @@ jobs:
       - name: Push to NuGet
         run: dotnet nuget push "./artifacts/*.nupkg" --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
 
-  publish-sdks:
+  publish-npm-sdks:
     runs-on: ubuntu-latest
     needs: release-please
     if: >-
-      needs.release-please.outputs['sdk--release_created'] == 'true' ||
-      needs.release-please.outputs['react--release_created'] == 'true'
+      needs.release-please.outputs['js-sdk--release_created'] == 'true' ||
+      needs.release-please.outputs['react-sdk--release_created'] == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -132,7 +132,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Publish @togglerino/sdk
-        if: needs.release-please.outputs['sdk--release_created'] == 'true'
+        if: needs.release-please.outputs['js-sdk--release_created'] == 'true'
         working-directory: sdks/javascript
         run: |
           npm ci
@@ -140,7 +140,7 @@ jobs:
           npm publish --access public --provenance
 
       - name: Publish @togglerino/react
-        if: needs.release-please.outputs['react--release_created'] == 'true'
+        if: needs.release-please.outputs['react-sdk--release_created'] == 'true'
         working-directory: sdks/react
         run: |
           npm ci

--- a/sdks/dotnet/README.md
+++ b/sdks/dotnet/README.md
@@ -1,5 +1,7 @@
 # Togglerino .NET SDK
 
+[![NuGet](https://img.shields.io/nuget/v/Togglerino.Sdk)](https://www.nuget.org/packages/Togglerino.Sdk)
+
 Official .NET SDK for [Togglerino](https://github.com/joCur/togglerino) feature flag management.
 
 ## Installation


### PR DESCRIPTION
## Summary

- Renamed SDK output aliases to consistent `{name}-sdk--` pattern (`js-sdk`, `react-sdk`, `dotnet-sdk`)
- Renamed `publish-sdks` job to `publish-npm-sdks` for clarity alongside `publish-dotnet-sdk`
- Added NuGet badge to .NET SDK README (touches `sdks/dotnet/` to trigger release-please for this component)

Follow-up to #115. Closes #89.

## Test plan

- [ ] Verify release-please includes `dotnet-sdk` component in next release PR (due to `sdks/dotnet/README.md` change)
- [ ] Confirm `publish-dotnet-sdk` job triggers when the release PR is merged
- [ ] Verify `publish-npm-sdks` job still works for JS/React SDK releases