### PR TITLE
feat: redesign flag list and detail page hierarchy

### DIFF
--- a/web/src/components/FlagCard.tsx
+++ b/web/src/components/FlagCard.tsx
@@ -122,25 +122,25 @@ export default function FlagCard({ flag, environments, getEnvStatus, onClick, se
         })}
       </div>
 
-      {/* Row 4: Owner + Purpose */}
-      <div className="flex items-center justify-between min-w-0">
+      {/* Row 4: Owner + Evaluated + Purpose */}
+      <div className="grid grid-cols-3 items-center min-w-0">
         {flag.owner ? (
-          <div className="flex items-center gap-1.5 min-w-0 shrink">
+          <div className="flex items-center gap-1.5 min-w-0">
             <img
               src={gravatarUrl(flag.owner.email, 20)}
               alt=""
               className="w-5 h-5 rounded-full shrink-0"
             />
-            <span className="text-[11px] text-muted-foreground/60 truncate max-w-[140px]">
+            <span className="text-[11px] text-muted-foreground/60 truncate">
               {flag.owner.display_name ?? flag.owner.email}
             </span>
           </div>
         ) : (
           <span />
         )}
-        {!isArchived && (
+        {!isArchived ? (
           <span className={cn(
-            'text-[11px] truncate shrink-0',
+            'text-[11px] truncate text-center',
             flag.last_evaluated_at
               ? 'text-muted-foreground/50'
               : 'text-amber-400/70',
@@ -149,8 +149,10 @@ export default function FlagCard({ flag, environments, getEnvStatus, onClick, se
               ? `Evaluated ${formatRelativeTime(flag.last_evaluated_at)}`
               : 'Never evaluated'}
           </span>
+        ) : (
+          <span />
         )}
-        <span className="text-[11px] text-muted-foreground/50 capitalize shrink-0">{flag.flag_type}</span>
+        <span className="text-[11px] text-muted-foreground/50 capitalize text-right">{flag.flag_type}</span>
       </div>
     </div>
   )

--- a/web/src/components/FlagCard.tsx
+++ b/web/src/components/FlagCard.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react'
 import type { Flag, Environment } from '../api/types.ts'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
 import { cn } from '@/lib/utils'
 import { gravatarUrl } from '@/lib/gravatar'
 import { formatRelativeTime } from '@/lib/date'
+import { Copy, Check } from 'lucide-react'
 
 interface Props {
   flag: Flag
@@ -17,6 +19,15 @@ interface Props {
 export default function FlagCard({ flag, environments, getEnvStatus, onClick, selected, onSelect }: Props) {
   const isArchived = flag.lifecycle_status === 'archived'
   const isSelectable = !!onSelect
+
+  const [copied, setCopied] = useState(false)
+
+  const handleCopyKey = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    navigator.clipboard.writeText(flag.key)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
 
   return (
     <div
@@ -43,15 +54,24 @@ export default function FlagCard({ flag, environments, getEnvStatus, onClick, se
         </div>
       )}
 
-      {/* Row 1: Key + Type */}
+      {/* Row 1: Name + Type */}
       <div className="flex items-center justify-between mb-1">
-        <span className="font-mono text-sm text-[#d4956a] tracking-wide">{flag.key}</span>
+        <span className="text-sm font-medium text-foreground">{flag.name}</span>
         <Badge variant="secondary" className="font-mono text-[11px]">{flag.value_type}</Badge>
       </div>
 
-      {/* Row 2: Name + lifecycle badge */}
+      {/* Row 2: Key (with copy) + lifecycle badge */}
       <div className="flex items-center gap-2 mb-3">
-        <span className="text-[13px] text-muted-foreground">{flag.name}</span>
+        <span className="font-mono text-[11px] text-[#d4956a]/70 tracking-wide">{flag.key}</span>
+        <button
+          onClick={handleCopyKey}
+          className="text-muted-foreground/40 hover:text-muted-foreground transition-colors"
+          title="Copy flag key"
+        >
+          {copied
+            ? <Check className="w-3 h-3 text-emerald-400" />
+            : <Copy className="w-3 h-3" />}
+        </button>
         {flag.lifecycle_status !== 'active' && flag.lifecycle_status !== 'archived' && (
           <Badge
             variant="secondary"

--- a/web/src/components/FlagCard.tsx
+++ b/web/src/components/FlagCard.tsx
@@ -22,11 +22,15 @@ export default function FlagCard({ flag, environments, getEnvStatus, onClick, se
 
   const [copied, setCopied] = useState(false)
 
-  const handleCopyKey = (e: React.MouseEvent) => {
+  const handleCopyKey = async (e: React.MouseEvent) => {
     e.stopPropagation()
-    navigator.clipboard.writeText(flag.key)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    try {
+      await navigator.clipboard.writeText(flag.key)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard API may not be available
+    }
   }
 
   return (

--- a/web/src/pages/FlagDetailPage.tsx
+++ b/web/src/pages/FlagDetailPage.tsx
@@ -38,7 +38,7 @@ import { useEnvironmentWriteAccess } from '@/hooks/useEnvironmentAccess'
 import PromoteDialog from '../components/PromoteDialog.tsx'
 import CompareTab from '../components/CompareTab.tsx'
 import { FlagOverrideControl } from '../components/FlagOverrideControl.tsx'
-import { Settings, Trash2, Archive, RotateCcw, AlertTriangle, Play, ArrowRightFromLine, Lock, Unlock, GitCompareArrows, History } from 'lucide-react'
+import { Settings, Trash2, Archive, RotateCcw, AlertTriangle, Play, ArrowRightFromLine, Lock, Unlock, GitCompareArrows, History, Copy, Check } from 'lucide-react'
 
 interface FlagDetailResponse {
   flag: Flag
@@ -61,6 +61,17 @@ export default function FlagDetailPage() {
   const [lockDialogState, setLockDialogState] = useState<{ open: boolean; envKey: string; envName: string } | null>(null)
   const [lockReason, setLockReason] = useState('')
   const [searchParams, setSearchParams] = useSearchParams()
+  const [copied, setCopied] = useState(false)
+
+  const handleCopyKey = async () => {
+    try {
+      await navigator.clipboard.writeText(flagKey!)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard API may not be available
+    }
+  }
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['projects', key, 'flags', flagKey],
@@ -226,7 +237,7 @@ export default function FlagDetailPage() {
       {/* Header: flag key + actions */}
       <div className="flex items-start justify-between mb-1">
         <div className="flex items-center gap-3">
-          <h1 className="text-xl font-mono text-[#d4956a] tracking-wide">{flag.key}</h1>
+          <h1 className="text-xl font-semibold text-foreground tracking-tight">{flag.name}</h1>
           <Link
             to={`/projects/${key}/playground?flag=${flag.key}`}
             className="inline-flex items-center gap-1.5 text-[12px] text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-foreground/[0.05]"
@@ -293,8 +304,19 @@ export default function FlagDetailPage() {
         </div>
       </div>
 
-      {/* Flag name */}
-      <div className="text-[15px] text-muted-foreground mb-2">{flag.name}</div>
+      {/* Flag key with copy */}
+      <div className="flex items-center gap-2 mb-2">
+        <span className="font-mono text-sm text-[#d4956a]/70 tracking-wide">{flag.key}</span>
+        <button
+          onClick={handleCopyKey}
+          className="text-muted-foreground/40 hover:text-muted-foreground transition-colors"
+          title="Copy flag key"
+        >
+          {copied
+            ? <Check className="w-3.5 h-3.5 text-emerald-400" />
+            : <Copy className="w-3.5 h-3.5" />}
+        </button>
+      </div>
 
       {/* Metadata chips */}
       <div className="flex flex-wrap items-center gap-2 text-[13px] text-muted-foreground/60 mb-2">

--- a/web/src/pages/FlagDetailPage.tsx
+++ b/web/src/pages/FlagDetailPage.tsx
@@ -454,7 +454,7 @@ export default function FlagDetailPage() {
             return next
           }, { replace: true })
         }} className="w-full">
-          <TabsList className="mb-6">
+          <TabsList variant="line" className="mb-6">
             {sortedEnvironments.map((env) => (
               <TabsTrigger key={env.key} value={env.key}>
                 {env.name}
@@ -539,6 +539,13 @@ export default function FlagDetailPage() {
                         </DropdownMenuContent>
                       </DropdownMenu>
                     )}
+                    <FlagOverrideControl
+                      projectKey={key!}
+                      flagKey={flagKey!}
+                      envKey={env.key}
+                      valueType={flag.value_type}
+                      override={overridesData?.find((o) => o.environment_key === env.key)}
+                    />
                   </div>
                 </div>
 
@@ -557,16 +564,6 @@ export default function FlagDetailPage() {
                     )}
                   </div>
                 )}
-
-                <div className="flex items-center justify-end mb-4">
-                  <FlagOverrideControl
-                    projectKey={key!}
-                    flagKey={flagKey!}
-                    envKey={env.key}
-                    valueType={flag.value_type}
-                    override={overridesData?.find((o) => o.environment_key === env.key)}
-                  />
-                </div>
 
                 {/* Pending schedules */}
                 <PendingSchedules


### PR DESCRIPTION
## Summary
- Flip flag name/key visual hierarchy: human-readable name is now primary, key is secondary with a copy-to-clipboard button
- Applied consistently to both FlagCard (list view) and FlagDetailPage (detail header)
- Fix inconsistent bottom row alignment in flag cards using CSS grid
- Consolidate flag detail actions bar (Lock, Promote, Override) into a single row
- Switch environment tabs to line variant for visual consistency

## Test plan
- [x] Flag list: verify name is prominent, key is smaller amber text below
- [x] Flag list: click copy button next to key, verify clipboard contains flag key and card does not navigate
- [x] Flag detail: verify name is the h1 heading, key below with copy button
- [x] Flag detail: verify Lock, Promote, Override for me are on a single row
- [x] Flag detail: verify environment tabs use underlined style
- [x] Test with different flag types (boolean, string, number)
- [x] Test with lifecycle badges (stale, potentially stale, archived)
- [x] Test mobile viewport for responsive behavior